### PR TITLE
Fixed pinout numbers and names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Having the wires mapped, solder/connect the wires to the Raspberry Pi Pico like 
 |Female connector|   |Raspberry Pi Pico|
 |:--------------:|:-:|:---------------:|
 |Pin 1 (3.3V)    |-> |3.3V pin         |
-|Pin 2 (SCL)     |-> |GP7 pin          |
-|Pin 5 (SDA)     |-> |GP6 pin          |
+|Pin 2 (SCL)     |-> |7 (GP4) pin      |
+|Pin 5 (SDA)     |-> |6 (GP5) pin      |
 |Pin 6 (ground)  |-> |Any GND pin      |
 
 ![female connector](nunchuck_port.png)


### PR DESCRIPTION
After some hours of debugging it seems that the pin names were wrong on the readme.

As it can be seen [here](https://datasheets.raspberrypi.com/pico/Pico-R3-A4-Pinout.pdf), the default I2C pins of the RPI PICO are GP4/GP5 which are pins number 6/7.

Thanks for the project, happy to contribute!